### PR TITLE
Add GitHub Action for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+        os: [ubuntu, macOS, windows]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Python ${{ matrix.python }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}-dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+    - name: Lint
+      run: poetry run invoke lint
+    - name: Test
+      run: poetry run invoke test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7]
         os: [ubuntu, macOS, windows]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
     - os: linux
       dist: xenial
       python: 3.7-dev
-    - os: linux
-      dist: xenial
-      python: 3.8-dev
     - os: osx
       # `xcode10.2` has Python 3.7.3.
       osx_image: xcode10.2


### PR DESCRIPTION
Conclusions:

- `actions/setup-python` cannot install Python on `macOS-latest`.
- `actions/setup-python` cannot install Python `3.8-dev` on any OS.